### PR TITLE
Refactor update handling for cross-platform compatibility

### DIFF
--- a/src/app/runtime/workers/auxiliary.rs
+++ b/src/app/runtime/workers/auxiliary.rs
@@ -83,7 +83,7 @@ pub fn spawn_auxiliary_workers(
     {
         // Save mirrors into the repository directory in the source tree and build the index via Arch API
         let repo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("repository");
-        let index_path = official_index_path.clone();
+        let index_path = official_index_path.to_path_buf();
         let net_err = net_err_tx.clone();
         let index_notify = index_notify_tx.clone();
         tokio::spawn(async move {

--- a/src/args/args.rs
+++ b/src/args/args.rs
@@ -147,8 +147,14 @@ pub fn process_args(args: &Args) -> bool {
     }
 
     // Handle system update (--update / -u)
+    #[cfg(not(target_os = "windows"))]
     if args.update {
         update::handle_update();
+    }
+    #[cfg(target_os = "windows")]
+    if args.update {
+        eprintln!("System update is not supported on Windows");
+        std::process::exit(1);
     }
 
     // Handle refresh flag

--- a/src/args/definition.rs
+++ b/src/args/definition.rs
@@ -150,8 +150,14 @@ pub fn process_args(args: &Args) -> Option<bool> {
     }
 
     // Handle system update (--update / -u)
+    #[cfg(not(target_os = "windows"))]
     if args.update {
         update::handle_update();
+    }
+    #[cfg(target_os = "windows")]
+    if args.update {
+        eprintln!("System update is not supported on Windows");
+        std::process::exit(1);
     }
 
     // Handle refresh flag

--- a/src/args/update.rs
+++ b/src/args/update.rs
@@ -1,7 +1,11 @@
 //! Command-line update functionality.
 
-use crate::args::{i18n, utils};
+use crate::args::i18n;
+#[cfg(not(target_os = "windows"))]
+use crate::args::utils;
+#[cfg(not(target_os = "windows"))]
 use pacsea::install::shell_single_quote;
+#[cfg(not(target_os = "windows"))]
 use pacsea::theme;
 use std::path::Path;
 
@@ -282,6 +286,7 @@ fn extract_failed_packages(output: &str, helper: &str) -> Vec<String> {
 /// - Preserves real-time output display while logging everything.
 /// - Returns the command output for parsing failed packages.
 /// - Output is parsed using locale-aware i18n patterns.
+#[cfg(not(target_os = "windows"))]
 fn run_command_with_logging(
     program: &str,
     args: &[&str],
@@ -336,6 +341,7 @@ fn run_command_with_logging(
 /// - Displays update progress output in real-time to the terminal.
 /// - Logs all command output and status messages to `update.log` in the config logs directory.
 /// - Informs user of final status and log file path.
+#[cfg(not(target_os = "windows"))]
 #[allow(clippy::too_many_lines)]
 pub fn handle_update() -> ! {
     use std::fs::OpenOptions;

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -71,4 +71,7 @@ pub fn spawn_aur_scan_for_with_config(
 }
 pub use shell::spawn_shell_commands_in_terminal;
 pub use single::spawn_install;
-pub use utils::{command_on_path, shell_single_quote};
+pub use utils::command_on_path;
+
+#[cfg(not(target_os = "windows"))]
+pub use utils::shell_single_quote;

--- a/src/install/remove.rs
+++ b/src/install/remove.rs
@@ -417,8 +417,8 @@ pub fn spawn_remove_all(names: &[String], dry_run: bool, cascade_mode: CascadeMo
             tracing::info!(
                 names = %names_str,
                 total = names.len(),
-                dry_run = _dry_run,
-                mode = ?_cascade_mode,
+                dry_run = dry_run,
+                mode = ?cascade_mode,
                 "launched cmd for removal"
             );
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Pacsea! Please read CONTRIBUTING.md before submitting. -->

## Summary
This PR refactors update handling and utility functions for cross-platform compatibility, specifically adding proper Windows support. The changes ensure that system update functionality gracefully exits on Windows with an appropriate error message, while maintaining full functionality on Unix-like systems. Additionally, it fixes a path cloning issue and corrects logging parameters in the removal process.

## Type of change

- [x] minor refactor (no functional change)


## Related issues
Closes #

## How to test
List exact steps and commands to verify the change. Include flags like `--dry-run` when appropriate.

```bash
# Format and lint
cargo fmt --all
cargo clippy --all-targets --all-features -- -D warnings

# Run tests
cargo test -- --test-threads=1

# Test on Linux/Unix (should work normally)
cargo run -- --update --dry-run

# Test on Windows (should exit with error message)
cargo run -- --update

# Verify other functionality still works
cargo run -- --refresh
cargo run -- --help
```

## Checklist
- [x] Code compiles locally
- [x] `cargo fmt --all` ran without changes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test -- --test-threads=1` passes
- [ ] Added or updated tests where it makes sense
- [ ] Updated docs if behavior, options, or keybinds changed (README, config examples)
- [ ] For UI changes: included screenshots and updated `Images/` if applicable
- [x] Changes respect `--dry-run` and degrade gracefully if `pacman`/`paru`/`yay` are unavailable
- [ ] If config keys changed: updated README sections for `settings.conf`, `theme.conf`, and `keybinds.conf`
- [x] Not a packaging change for AUR (otherwise propose in `pacsea-bin` or `pacsea-git` repos)

## Notes for reviewers
- **Windows compatibility**: The `--update` flag now exits with a clear error message on Windows, as system updates are not supported on that platform. This prevents attempting to run unsupported operations.
- **Conditional compilation**: Several utility functions (`shell_single_quote`, `handle_update`, `run_command_with_logging`) are now conditionally compiled only for non-Windows platforms using `#[cfg(not(target_os = "windows"))]`.
- **Path handling fix**: Changed `official_index_path.clone()` to `official_index_path.to_path_buf()` in `auxiliary.rs` for better path handling.
- **Logging fix**: Fixed logging parameters in `remove.rs` to use the actual `dry_run` and `cascade_mode` variables instead of prefixed versions (`_dry_run`, `_cascade_mode`).

## Breaking changes
None. This is a refactoring that maintains backward compatibility on Unix-like systems while adding proper Windows handling.

## Additional context
This PR is part of the Windows cleanup effort to ensure Pacsea handles Windows platforms gracefully. The changes ensure that:
1. Windows users get a clear error message when attempting to use unsupported features
2. Code that is Unix-specific is properly gated behind platform conditionals
3. Minor bugs in path handling and logging are fixed

Files changed:
- `src/app/runtime/workers/auxiliary.rs`: Fixed path cloning
- `src/args/args.rs`: Added Windows-specific update handling
- `src/args/definition.rs`: Added Windows-specific update handling
- `src/args/update.rs`: Made update functions conditional on non-Windows
- `src/install/mod.rs`: Made `shell_single_quote` conditional on non-Windows
- `src/install/remove.rs`: Fixed logging parameters

