### PR TITLE
Translation: Update hu-HU.yml

### DIFF
--- a/config/locales/hu-HU.yml
+++ b/config/locales/hu-HU.yml
@@ -506,7 +506,7 @@ hu-HU:
           data_will_update: "Az adatok még feldolgozás alatt állnak. A darabszám automatikusan frissül."
         deps:
           dependents_rely_on: "Függőségi csomagok: {} csomag is függ az eltávolítási listán szereplőtől"
-          no_deps_for_removal: "Nem találhatók ellentétes függőségek. A csomagok biztonságosan eltávolíthatók."
+          no_deps_for_removal: "Nem találhatók fordított függőségek. A csomagok biztonságosan eltávolíthatók."
           meta_package_warning: "⚠ Megjegyzés: A(z) „{}” egy metacsomag. Bár semmi sem függ közvetlenül tőle, az eltávolítása hatással lehet a rendszer alapvető telepítési állapotára."
           dependencies_label: "Függőségek: {}"
           total: "összesen: {}"


### PR DESCRIPTION
1st commit: Translate new strings
2nd commit: Fix wording for word reverse => fordított more accurate than ellentétes in hungarian.