### PR TITLE
fix: Block global keybinds when modals are open

### DIFF
--- a/src/events/global.rs
+++ b/src/events/global.rs
@@ -631,6 +631,8 @@ fn handle_menu_numeric_selection(
 ///
 /// Details:
 /// - Checks key event against all global keybinds using a dispatch pattern.
+/// - When a modal is open (except None), only exit keybind works globally.
+/// - Other global keybinds are blocked to let modals handle their own keys.
 fn handle_global_keybinds(
     ke: &KeyEvent,
     app: &mut AppState,
@@ -640,6 +642,20 @@ fn handle_global_keybinds(
     query_tx: &mpsc::UnboundedSender<crate::state::QueryInput>,
 ) -> Option<bool> {
     let km = &app.keymap;
+
+    // Exit should always work, even in modals (Ctrl+C to quit the app)
+    if matches_keybind(ke, &km.exit) {
+        return Some(handle_exit());
+    }
+
+    // When a modal is open, block most global keybinds to let the modal handle keys
+    // Exceptions: Modal::None (no modal), Preflight (has complex interaction with globals)
+    if !matches!(
+        app.modal,
+        crate::state::Modal::None | crate::state::Modal::Preflight { .. }
+    ) {
+        return None; // Let modal handler process the key
+    }
 
     // Log Ctrl+T specifically for debugging
     if ke.code == KeyCode::Char('t') && ke.modifiers.contains(KeyModifiers::CONTROL) {
@@ -668,11 +684,6 @@ fn handle_global_keybinds(
     // Configuration reload
     if matches_keybind(ke, &km.reload_config) {
         return Some(handle_reload_config(app, query_tx));
-    }
-
-    // Exit
-    if matches_keybind(ke, &km.exit) {
-        return Some(handle_exit());
     }
 
     // PKGBUILD toggle


### PR DESCRIPTION
<!-- Thank you for contributing to Pacsea! 

**Important references:**
- [CONTRIBUTING.md](../CONTRIBUTING.md) — Full contribution guidelines and PR process
- [PR_DESCRIPTION.md](../Documents/PR_DESCRIPTION.md) — Detailed PR description template
- [Development Wiki](https://github.com/Firstp1ck/Pacsea/wiki/Development) — Development tools and debugging

Please ensure you've reviewed these before submitting your PR.
-->

## Summary
Fixed keybind conflict where global keybinds (like `Ctrl+R` for config reload) were triggering even when modals were open, preventing modal-specific keybinds from working correctly. For example, `Ctrl+R` in the News modal should trigger "mark all read" but was instead triggering config reload.

The fix ensures that when any modal is open (except `Preflight` which has complex global interactions), global keybinds are blocked and only modal-specific keybinds work. Only the exit keybind (`Ctrl+C`) continues to work globally to allow users to quit the application.

## Type of change
- [x] fix (bug fix)
- [x] test (add/update tests)

## Related issues
Closes # (if applicable)

## How to test
List exact steps and commands to verify the change. Include flags like `--dry-run` when appropriate.

```bash
# Run tests to verify global keybind blocking
cargo test global_keybind -- --test-threads=1
cargo test modal_keybinds_priority -- --test-threads=1
cargo test news_ctrl_r -- --test-threads=1

# Run all tests
cargo fmt --all
cargo clippy --all-targets --all-features -- -D warnings
cargo test -- --test-threads=1

# Manual testing:
# 1. Open News modal (Options -> News)
# 2. Press Ctrl+R - should mark all items as read, NOT reload config
# 3. Open any other modal (Alert, SystemUpdate, etc.)
# 4. Press Ctrl+R, Ctrl+X, Ctrl+S, Ctrl+T, F1 - should NOT trigger global actions
# 5. Press Ctrl+C - should still exit the app (exit always works)
```

## Screenshots / recordings (if UI changes)
No UI changes - this is a keybind behavior fix.

## Checklist

**Code Quality:**
- [x] Code compiles locally (`cargo check`)
- [x] `cargo fmt --all` ran without changes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test -- --test-threads=1` passes
- [x] Complexity checks pass for new code (`cargo test complexity -- --nocapture`)
- [x] All new functions/methods have rustdoc comments (What, Inputs, Output, Details)
- [x] No `unwrap()` or `expect()` in non-test code

**Testing:**
- [x] Added or updated tests where it makes sense
- [x] For bug fixes: created failing tests first, then fixed the issue
- [x] Tests are meaningful and cover the functionality

**Documentation:**
- [ ] Updated README if behavior, options, or keybinds changed (keep high-level, reference wiki)
- [ ] Updated relevant wiki pages if needed:
  - [How to use Pacsea](https://github.com/Firstp1ck/Pacsea/wiki/How-to-use-Pacsea)
  - [Configuration](https://github.com/Firstp1ck/Pacsea/wiki/Configuration)
  - [Keyboard Shortcuts](https://github.com/Firstp1ck/Pacsea/wiki/Keyboard-Shortcuts)
- [ ] Updated config examples in `config/` directory if config keys changed
- [ ] For UI changes: included screenshots and updated `Images/` if applicable

**Compatibility:**
- [x] Changes respect `--dry-run` flag
- [x] Code degrades gracefully if `pacman`/`paru`/`yay` are unavailable
- [x] No breaking changes (or clearly documented if intentional)

**Other:**
- [x] Not a packaging change for AUR (otherwise propose in `pacsea-bin` or `pacsea-git` repos)

## Notes for reviewers

**Key Changes:**
1. **Global keybind blocking**: Modified `handle_global_keybinds()` to check if a modal is open before processing global keybinds. When a modal is active (except `None` and `Preflight`), global keybinds return `None` to let the modal handler process the key.

2. **Exit keybind exception**: Exit (`Ctrl+C`) is checked first and always works, even in modals, to allow users to quit the application.

3. **Preflight exception**: Preflight modal maintains its current behavior where some global keybinds (like `Ctrl+T` for comments toggle) work while Preflight is open. This is intentional due to Preflight's complex interaction model.

**Test Coverage:**
- Added comprehensive tests for all modal types verifying global keybinds (`Ctrl+R`, `Ctrl+X`, `Ctrl+S`, `Ctrl+T`, `F1`) are blocked
- Added specific test for the original issue (`Ctrl+R` in News modal)
- Added baseline test ensuring global keybinds work when no modal is open

**Edge Cases:**
- `PostSummary` modal uses 'r' for rollback - test verifies this is modal action, not config reload
- `Preflight` modal maintains its current global keybind behavior
- Exit keybind always works globally

## Breaking changes
None - this fixes incorrect behavior where global keybinds were interfering with modal keybinds.

## Additional context

**Problem:**
When modals were open, global keybinds were checked first, causing conflicts. For example:
- `Ctrl+R` in News modal should mark all items as read, but was triggering config reload instead
- Other global keybinds could interfere with modal-specific actions

**Solution:**
Restructured global keybind handling to:
1. Check exit keybind first (always works)
2. Block other global keybinds when modals are open (except Preflight)
3. Let modal handlers process keys with priority

**Benefits:**
- Cleaner, more maintainable code (no per-keybind exclusions needed)
- Automatic protection for new modals
- Automatic protection for new global keybinds
- Better user experience - modal keybinds work as expected

